### PR TITLE
Enable ruff formatting and linting in actions

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,16 @@
+name: Check formatting with ruff
+on:
+  push:
+    paths:
+      - '**.py'
+      - .github/workflows/ruff.yml
+
+jobs:
+  check-ruff:
+    runs-on: ubuntu-latest
+    name: Check format
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Ruff check
+        uses: astral-sh/ruff-action@v3

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -12,5 +12,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Ruff check
+      - name: Ruff check lint
         uses: astral-sh/ruff-action@v3
+      - name: Ruff check format
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check"
+      - name: Ruff check imports
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "check --select I"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     # Run the linter.
     - id: ruff-check
-      types_or: [ python, pyi ]
+      types_or: [ python, pyi, jupyter ]
       args: [ --fix ]
     # Run isort.
     - id: ruff-check

--- a/demos/roc_to_tile.ipynb
+++ b/demos/roc_to_tile.ipynb
@@ -65,7 +65,7 @@
     "    roc_ax, tile_ax = axes\n",
     "    tile.draw(fig, tile_ax)\n",
     "    performance.drawInROC(fig, roc_ax)\n",
-    "    draw_cbar = False\n"
+    "    draw_cbar = False"
    ]
   },
   {

--- a/demos/tile_to_roc.ipynb
+++ b/demos/tile_to_roc.ipynb
@@ -19,10 +19,10 @@
     "from matplotlib.backend_bases import MouseButton\n",
     "from matplotlib.widgets import Slider\n",
     "\n",
+    "from sorbetto.annotation import AnnotationText\n",
     "from sorbetto.parameterization import ParameterizationDefault\n",
-    "from sorbetto.tile import Tile\n",
     "from sorbetto.ranking import RankingScore\n",
-    "from sorbetto.annotation import AnnotationText"
+    "from sorbetto.tile import Tile"
    ]
   },
   {

--- a/examples/entity_tile.ipynb
+++ b/examples/entity_tile.ipynb
@@ -25,13 +25,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sorbetto.core.entity import Entity\n",
+    "from sorbetto.flavor.entity_flavor import EntityFlavor\n",
+    "from sorbetto.parameterization.parameterization_default import ParameterizationDefault\n",
     "from sorbetto.performance.two_class_classification_performance import (\n",
     "    TwoClassClassificationPerformance,\n",
     ")\n",
-    "from sorbetto.core.entity import Entity\n",
-    "from sorbetto.tile.entity_tile import EntityTile\n",
-    "from sorbetto.flavor.entity_flavor import EntityFlavor\n",
-    "from sorbetto.parameterization.parameterization_default import ParameterizationDefault"
+    "from sorbetto.tile.entity_tile import EntityTile"
    ]
   },
   {

--- a/examples/ranking_tile.ipynb
+++ b/examples/ranking_tile.ipynb
@@ -25,13 +25,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sorbetto.core.entity import Entity\n",
+    "from sorbetto.flavor.ranking_flavor import RankingFlavor\n",
+    "from sorbetto.parameterization.parameterization_default import ParameterizationDefault\n",
     "from sorbetto.performance.two_class_classification_performance import (\n",
     "    TwoClassClassificationPerformance,\n",
     ")\n",
-    "from sorbetto.core.entity import Entity\n",
-    "from sorbetto.tile.ranking_tile import RankingTile\n",
-    "from sorbetto.flavor.ranking_flavor import RankingFlavor\n",
-    "from sorbetto.parameterization.parameterization_default import ParameterizationDefault"
+    "from sorbetto.tile.ranking_tile import RankingTile"
    ]
   },
   {

--- a/examples/value_tile.ipynb
+++ b/examples/value_tile.ipynb
@@ -25,12 +25,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sorbetto.flavor.value_flavor import ValueFlavor\n",
+    "from sorbetto.parameterization.parameterization_default import ParameterizationDefault\n",
     "from sorbetto.performance.two_class_classification_performance import (\n",
     "    TwoClassClassificationPerformance,\n",
     ")\n",
-    "from sorbetto.flavor.value_flavor import ValueFlavor\n",
-    "from sorbetto.tile.value_tile import ValueTile\n",
-    "from sorbetto.parameterization.parameterization_default import ParameterizationDefault"
+    "from sorbetto.tile.value_tile import ValueTile"
    ]
   },
   {
@@ -92,11 +92,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sorbetto.annotation.annotation_text import AnnotationText\n",
-    "from sorbetto.annotation.annotation_isovalue_curves import AnnotationIsovalueCurves\n",
     "from sorbetto.annotation.annotation_curve_fixed_class_priors import (\n",
     "    AnnotationCurveFixedClassPriors,\n",
     ")\n",
+    "from sorbetto.annotation.annotation_isovalue_curves import AnnotationIsovalueCurves\n",
+    "from sorbetto.annotation.annotation_text import AnnotationText\n",
     "from sorbetto.ranking.ranking_score import RankingScore"
    ]
   },

--- a/sorbetto/core/entity.py
+++ b/sorbetto/core/entity.py
@@ -8,6 +8,9 @@ from sorbetto.performance.two_class_classification_performance import (
 
 
 class Entity:
+
+
+    
     def __init__(
         self,
         performance: TwoClassClassificationPerformance,

--- a/sorbetto/core/entity.py
+++ b/sorbetto/core/entity.py
@@ -8,9 +8,6 @@ from sorbetto.performance.two_class_classification_performance import (
 
 
 class Entity:
-
-
-    
     def __init__(
         self,
         performance: TwoClassClassificationPerformance,


### PR DESCRIPTION
In order to keep the code consistent in case someone does not use the pre-commit hook.

This also enables the pre-commit to format the notebooks so that the examples and demos are consistent too.