### PR TITLE
Fix errors and omissions in docs

### DIFF
--- a/LICENSE-3RD-PARTY
+++ b/LICENSE-3RD-PARTY
@@ -1,0 +1,26 @@
+# Third-Party Licenses
+
+## Numpy
+
+Licensed under a modified BSD license
+[https://github.com/numpy/numpy]
+
+## Matplotlib
+
+Licensed under a modified PSF license
+[https://github.com/matplotlib/matplotlib]
+
+## Scipy
+
+Licensed under the BSD license
+[https://github.com/scipy/scipy]
+
+## Jax
+
+Licensed under the Apache-2.0 license
+[https://github.com/jax-ml/jax]
+
+## TQDM
+
+Licensed under the MPL-2.0 and MIT licenses
+[https://github.com/tqdm/tqdm]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![sorbetto banner](doc/images/sorbetto_banner.svg)
+![sorbetto banner](https://raw.githubusercontent.com/uliege-performance/sorbetto/ff6c10fb1e89097dfb6d75090702023bc5393459/doc/images/sorbetto_banner.svg)
 
 **Disclaimer: Sorbetto is currently in its early development phase, coming
 updates might introduce some breaking changes.**

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ welcome it! Please go through our
 [contributor guidelines](https://sorbetto.readthedocs.io/en/stable/src/contributing.html)
 to get started.
 
+## Citing us
+
+If you use this code in your work, please cite us accordingly as described in
+our documentation [here](https://sorbetto.readthedocs.io/en/stable/src/citing.html).
+
 ## License
 
 Copyright 2025 Sebastien Pierard, Anais Halin, Francois Marelli, Simon Pernas, Jerome Pierre

--- a/README.md
+++ b/README.md
@@ -26,17 +26,18 @@ pip install .
 
 ## Getting started
 
-Check out our interactive demos to learn about the core concepts of Sorbetto
-[here](https://sorbetto.readthedocs.io/en/latest/demos.html)!
+Check out our tutorials to learn about the core concepts of Sorbetto
+[here](https://sorbetto.readthedocs.io/en/stable/src/tutorial.html)!
 
-You can also have a look at our detailed example notebooks
-[here](https://sorbetto.readthedocs.io/en/latest/examples.html).
+You can also have a look at our detailed
+[example notebooks](https://sorbetto.readthedocs.io/en/stable/src/examples.html)
+and [interactive demos](https://sorbetto.readthedocs.io/en/stable/src/demos.html).
 
 ## Contributing
 
 If you want to bring your contribution to this library, we will be happy to
 welcome it! Please go through our
-[contributor guidelines](https://sorbetto.readthedocs.io/en/latest/contributing.html)
+[contributor guidelines](https://sorbetto.readthedocs.io/en/stable/src/contributing.html)
 to get started.
 
 ## License

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,6 +13,9 @@ the main concepts used in this library through interactive, as well as
 <Demos>`. You will also find a complete API reference with detailed
 descriptions.
 
+Feel free to check out the source code on `GitHub
+<https://github.com/uliege-performance/sorbetto>`__!
+
 
 Contact and support
 -------------------


### PR DESCRIPTION
This fixes broken links and images in the readme, and adds a license file for 3rd party libs.
It also adds a link to github in the doc, and citation instructions in the readme.